### PR TITLE
Revert #2

### DIFF
--- a/src/articles/jsdoc-cheatsheet.mdx
+++ b/src/articles/jsdoc-cheatsheet.mdx
@@ -217,16 +217,3 @@ function login(auth) {
   return authenticateWithThirdPartyService(auth)
 }
 ```
-
-
-## Typing React hooks
-
-Declaring the type of the initial value is equivalent to specifying the generic type as `const [user, setUser] = useState<User>(null)`
-
-```js
-export default function Component(props) {
-  /** @type {User} */
-  const initialState = null;
-  const [user, setUser] = useState(initialState)
-}
-```


### PR DESCRIPTION
@JacobParis Really recommend reverting PR #2 (or doing a new PR fixing it).

This PR is recommending broken types.

Here's a test repo (with GitHub Actions to show TSC is failing): https://github.com/karlhorky/jsdoc-checkjs-test

Check the error message here: https://github.com/karlhorky/jsdoc-checkjs-test/runs/2924139115

![Screen Shot 2021-06-27 at 08 48 50](https://user-images.githubusercontent.com/1935696/123535597-1ae66280-d725-11eb-841e-aca636cfb107.png)

You can also clone the project, run `npm install` / `yarn` and then see the errors in your editor:

<img width="1053" alt="Screen Shot 2021-06-27 at 08 43 50" src="https://user-images.githubusercontent.com/1935696/123535685-b546a600-d725-11eb-9558-dab1ff2cc410.png">

The difference with @oliverturner's project is that in that project, he doesn't have the configuration to actually check the types (something in the setup is preventing that from happening - probably `checkJs` is not enabled). So TS will just accept any type that you want, without any checks.